### PR TITLE
Update Costs of LLMs.md

### DIFF
--- a/Costs of LLMs.md
+++ b/Costs of LLMs.md
@@ -1,3 +1,5 @@
+# Costs of LLMs
+
 Training large language models (LLMs) involves substantial computational resources and financial investment. The costs have varied significantly across different models and over time:
 
 - **GPT-3 (2020):** Training costs were estimated between $2 million and $4 million. citeturn0search2
@@ -11,3 +13,5 @@ Training large language models (LLMs) involves substantial computational resourc
 These figures illustrate the substantial investments required for developing advanced LLMs, though recent innovations have demonstrated potential for more cost-effective approaches.
 
 navlistRecent Developments in AI Training Coststurn0news10,turn0news11,turn0news12 
+
+## The costs to reach where it is and a American's real :LLM 


### PR DESCRIPTION
# Costs of LLMs

Training large language models (LLMs) involves substantial computational resources and financial investment. The costs have varied significantly across different models and over time:

- **GPT-3 (2020):** Training costs were estimated between $2 million and $4 million. citeturn0search2

- **PaLM (2022):** Google's PaLM model incurred training costs ranging from $3 million to $12 million. citeturn0search2

- **GPT-4 (2023):** Estimates suggest training costs around $20 million. citeturn0search3

- **DeepSeek-R1 (2025):** The Chinese startup DeepSeek developed the R1 model with a training cost of approximately $5.6 million, significantly lower than its predecessors. citeturn0news12

These figures illustrate the substantial investments required for developing advanced LLMs, though recent innovations have demonstrated potential for more cost-effective approaches.

navlistRecent Developments in AI Training Coststurn0news10,turn0news11,turn0news12 

## The costs to reach where it is and a American's real :LLM